### PR TITLE
Only import used icons

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -7,47 +7,6 @@ store.commit('initialiseStore')
 import router from './router'
 
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
-import { library } from '@fortawesome/fontawesome-svg-core'
-import {
-  faDownload as pwaInstall,
-  faSyncAlt as pwaUpdate,
-  faUserCircle as user,
-  faHourglassStart as startTime,
-  faHourglassEnd as endTime,
-  // faCheckCircle as selectedCheckbox,
-  faDotCircle as selectedRadioButton,
-  faShareNodes as share,
-  faTimes as cross,
-  faPlus as plus,
-  faArrowCircleLeft as arrowLeft,
-  faArrowCircleRight as arrowRight,
-  faCogs as settings,
-  faGlobeEurope as globeEurope,
-  faExclamationCircle as warning,
-} from '@fortawesome/free-solid-svg-icons'
-import {
-  faUserCircle as userSelected,
-  faCircle as unselectedRadioOrCheckbox,
-} from '@fortawesome/free-regular-svg-icons'
-import { faTwitter as twitter } from '@fortawesome/free-brands-svg-icons'
-library.add(
-  pwaInstall,
-  pwaUpdate,
-  user,
-  userSelected,
-  startTime,
-  endTime,
-  unselectedRadioOrCheckbox,
-  selectedRadioButton, //selectedCheckbox, // Currently no checkboxes in app
-  share,
-  cross,
-  plus,
-  arrowLeft,
-  arrowRight,
-  settings,
-  globeEurope,
-  warning,
-  twitter
-)
+import './plugins/fontawesome'
 
 createApp(App).use(store, key).use(router).component('font-awesome-icon', FontAwesomeIcon).mount('#app')

--- a/src/plugins/fontawesome.ts
+++ b/src/plugins/fontawesome.ts
@@ -1,0 +1,49 @@
+import { library } from '@fortawesome/fontawesome-svg-core'
+
+import {
+  faDownload as pwaInstall,
+  faSyncAlt as pwaUpdate,
+  faUserCircle as user,
+  faHourglassStart as startTime,
+  faHourglassEnd as endTime,
+  // faCheckCircle as selectedCheckbox,
+  faDotCircle as selectedRadioButton,
+  faShareNodes as share,
+  faTimes as cross,
+  faPlus as plus,
+  faArrowCircleLeft as arrowLeft,
+  faArrowCircleRight as arrowRight,
+  faCogs as settings,
+  faGlobeEurope as globeEurope,
+  faExclamationCircle as warning,
+} from '@fortawesome/free-solid-svg-icons'
+
+import {
+  faUserCircle as userSelected,
+  faCircle as unselectedRadioOrCheckbox,
+} from '@fortawesome/free-regular-svg-icons'
+
+import {
+  faTwitter as twitter
+} from '@fortawesome/free-brands-svg-icons'
+
+library.add(
+  pwaInstall,
+  pwaUpdate,
+  user,
+  userSelected,
+  startTime,
+  endTime,
+  unselectedRadioOrCheckbox,
+  selectedRadioButton, 
+  //selectedCheckbox, // Currently no checkboxes in app
+  share,
+  cross,
+  plus,
+  arrowLeft,
+  arrowRight,
+  settings,
+  globeEurope,
+  warning,
+  twitter
+)


### PR DESCRIPTION
Closes #40

Before (dev @ 2d70d4fb928b4261ca19380e6b3fd4e0a8046cc0):

```
dist/index.html                  1.66 KiB
dist/manifest.webmanifest        0.41 KiB
dist/assets/index.85be0fde.css   40.51 KiB / gzip: 6.84 KiB
dist/assets/index.5e4fb71a.js    26.46 KiB / gzip: 8.29 KiB
dist/assets/vendor.f9466277.js   1808.62 KiB / gzip: 662.29 KiB
```

After:

```
dist/index.html                  1.66 KiB
dist/manifest.webmanifest        0.41 KiB
dist/assets/index.f88b1c14.js    26.61 KiB / gzip: 8.38 KiB
dist/assets/index.85be0fde.css   40.51 KiB / gzip: 6.84 KiB
dist/assets/vendor.00e895e7.js   354.93 KiB / gzip: 121.05 KiB
```